### PR TITLE
Fix tests ar 5.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: ruby
-sudo: false
 bundler_args: --without "oracle sqlserver"
 
 before_script:
   - cp test/connections/databases.ci.yml test/connections/databases.yml
-  - rake mysql:build_database postgresql:build_database sqlite:build_database
+  - bundle exec rake postgresql:build_database mysql:build_database sqlite:build_database
 
 script:
-  - "rake postgresql:test"
-  - "rake sqlite:test"
-  - "rake mysql:test"
+  - "bundle exec rake postgresql:test"
+  - "bundle exec rake mysql:test"
+  - "bundle exec rake sqlite:test"
 
 rvm:
   - 2.4.5
@@ -17,4 +16,9 @@ rvm:
   - 2.6.2
 
 env:
-  - CPK_LOGFILE=log/test.log
+  global:
+    - CPK_LOGFILE=log/test.log
+
+services:
+  - postgresql
+  - mysql

--- a/composite_primary_keys.gemspec
+++ b/composite_primary_keys.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   # Dependencies
   s.required_ruby_version = '>= 2.2.2'
 
-  s.add_dependency('activerecord', '~> 5.2.1')
+  s.add_dependency('activerecord', '~> 5.2.4')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('mysql2')

--- a/lib/composite_primary_keys/reflection.rb
+++ b/lib/composite_primary_keys/reflection.rb
@@ -1,19 +1,28 @@
 module ActiveRecord
   module Reflection
     class AbstractReflection
-      def build_join_constraint(table, foreign_table)
+      # Overriding for activerecord v5.2.4
+      def join_scope(table, foreign_table, foreign_klass)
+        predicate_builder = predicate_builder(table)
+        scope_chain_items = join_scopes(table, predicate_builder)
+        klass_scope       = klass_join_scope(table, predicate_builder)
+
         key         = join_keys.key
         foreign_key = join_keys.foreign_key
 
         # CPK
-        #constraint = table[key].eq(foreign_table[foreign_key])
-        constraint = cpk_join_predicate(table, key, foreign_table, foreign_key)
+        # klass_scope.where!(table[key].eq(foreign_table[foreign_key]))
+        klass_scope.where!(cpk_join_predicate(table, key, foreign_table, foreign_key))
+
+        if type
+          klass_scope.where!(type => foreign_klass.polymorphic_name)
+        end
 
         if klass.finder_needs_type_condition?
-          table.create_and([constraint, klass.send(:type_condition, table)])
-        else
-          constraint
+          klass_scope.where!(klass.send(:type_condition, table))
         end
+
+        scope_chain_items.inject(klass_scope, &:merge!)
       end
     end
   end

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -49,7 +49,7 @@ class TestCreate < ActiveSupport::TestCase
   end
 
   def test_create_generated_keys
-    if [nil, 'postgresql', 'sqlite'].exclude?(ENV['ADAPTER'])
+    if [nil, 'postgresql'].exclude?(ENV['ADAPTER'])
       skip 'Not all databases support columns with multiple identity fields'
     end
 
@@ -181,7 +181,7 @@ class TestCreate < ActiveSupport::TestCase
   end
 
   def test_create_when_pk_has_default_value
-    if [nil, 'postgresql', 'sqlite'].exclude?(ENV['ADAPTER'])
+    if [nil, 'postgresql'].exclude?(ENV['ADAPTER'])
       skip 'Not all databases support columns with multiple identity fields'
     end
 

--- a/test/test_create.rb
+++ b/test/test_create.rb
@@ -49,14 +49,13 @@ class TestCreate < ActiveSupport::TestCase
   end
 
   def test_create_generated_keys
-    # Not all databases support columns with multiple identity fields
-    if defined?(ActiveRecord::ConnectionAdapters::PostgreSQL) ||
-       defined?(ActiveRecord::ConnectionAdapters::SQLite3)
-
-      suburb = Suburb.create!(:name => 'Capitol Hill')
-      refute_nil(suburb.city_id)
-      refute_nil(suburb.suburb_id)
+    if [nil, 'postgresql', 'sqlite'].exclude?(ENV['ADAPTER'])
+      skip 'Not all databases support columns with multiple identity fields'
     end
+
+    suburb = Suburb.create!(:name => 'Capitol Hill')
+    refute_nil(suburb.city_id)
+    refute_nil(suburb.suburb_id)
   end
 
   def test_create_on_association
@@ -182,6 +181,10 @@ class TestCreate < ActiveSupport::TestCase
   end
 
   def test_create_when_pk_has_default_value
+    if [nil, 'postgresql', 'sqlite'].exclude?(ENV['ADAPTER'])
+      skip 'Not all databases support columns with multiple identity fields'
+    end
+
     first = CpkWithDefaultValue.create!
     refute_nil(first.record_id)
     assert_equal('', first.record_version)


### PR DESCRIPTION
* Fix .travis.yml:
  * Use `bundle exec` to run `rake`.
  * Add `services` section.
  * Fix `env` section.
  * Reorder commands by adapter: postgresql, mysql, sqlite.
* Fix joining for activerecord 5.2.4.
* Fix tests for mysql and sqlite.